### PR TITLE
Do not relocate the mounted docker.sock

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -50,15 +50,9 @@ var (
 )
 
 func (woc *wfOperationCtx) getVolumeMountDockerSock() apiv1.VolumeMount {
-	dockerSockPath := "/var/run/docker.sock"
-
-	if woc.controller.Config.DockerSockPath != "" {
-		dockerSockPath = woc.controller.Config.DockerSockPath
-	}
-
 	return apiv1.VolumeMount{
 		Name:      common.DockerSockVolumeName,
-		MountPath: dockerSockPath,
+		MountPath: "/var/run/docker.sock",
 		ReadOnly:  true,
 	}
 }


### PR DESCRIPTION
The mount path of the docker.sock should not depend on the host path of the docker.sock

#1606